### PR TITLE
ci: add test and container deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: DeterminateSystems/nix-installer-action@v21
       - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - name: Cache Mix dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: mix-${{ runner.os }}-${{ hashFiles('mix.lock') }}
+          restore-keys: |
+            mix-${{ runner.os }}-
       - name: Run tests
         run: nix develop --command bash -c "mix deps.get && mix format --check-formatted && mix test"
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` with two jobs: `test` and `deploy`
- **Test job** runs on all PRs and pushes to main — installs Nix, runs `mix deps.get`, `mix format --check-formatted`, and `mix test`
- **Deploy job** runs only on pushes to main after tests pass — builds the Nix OCI image, tags it with `latest` and the 7-char commit SHA, and pushes both to `ghcr.io/jordangarrison/greenlight`
- Uses `DeterminateSystems/nix-installer-action@v21` and `magic-nix-cache-action@v13` for fast Nix setup with caching
- Adds concurrency control to cancel redundant in-progress runs on the same branch
- Uses `GITHUB_TOKEN` for GHCR authentication (no additional secrets needed)

## Test plan

- [x] PR triggers the `test` job and it passes
- [ ] `deploy` job does not run on the PR (only on pushes to main)
- [ ] After merging, `deploy` job runs and pushes image to GHCR with both `latest` and SHA tags