### PR TITLE
fix: update stale Nix deps hash and add build CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,23 @@ jobs:
       - name: Run tests
         run: nix develop --command bash -c "mix deps.get && mix format --check-formatted && mix test"
 
+  build:
+    name: Nix Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - name: Build Nix package
+        run: nix build .#default
+      - name: Build Docker image
+        run: nix build .#dockerImage
+
   deploy:
     name: Build & Push Container
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
-    needs: [test]
+    needs: [test, build]
     permissions:
       contents: read
       packages: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,18 @@ custom classes must fully style the input
 - Focus on **delightful details** like hover effects, loading states, and smooth page transitions
 
 
+## Nix build & dependency management
+
+This project is packaged with Nix (`nix/package.nix`) and deployed as a Docker image (`nix/docker.nix`). The Nix package uses `fetchMixDeps` with a **pinned hash** for reproducibility.
+
+**When you add, remove, or update deps in `mix.exs`:**
+1. Run `nix build .#default` — if the hash is stale, the build will fail with a hash mismatch showing the correct `got:` value
+2. Update the `hash` in `nix/package.nix` with the new value
+3. Run `nix build .#default` again to confirm it succeeds
+4. Run `nix build .#dockerImage` to confirm the container image builds
+
+**Always validate both nix builds before committing dependency changes.**
+
 ## Structured Logging (Wide Events)
 
 This project uses structured wide event logging via `Greenlight.WideEvent` with LoggerJSON. Every logical operation emits a single JSON event with accumulated context. Use the `greenlight-debugging` skill when diagnosing issues.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -16,7 +16,7 @@ let
   mixFodDeps = fetchMixDeps {
     pname = "${pname}-mix-deps";
     inherit version src;
-    hash = "sha256-Wbv2hJLD1Wwcp+CmMuNuT5GB0BVKccHCjzDhBZpysso=";
+    hash = "sha256-ekvwtyOduUlUdoIO8s359yDLGGq2VDRzMVvYG8AJVz0=";
   };
 
   npmDeps = fetchNpmDeps {


### PR DESCRIPTION
## Summary
- Updated the stale `mixFodDeps` hash in `nix/package.nix` that was missing the `logger_json` dependency, causing the Docker image build to fail with `Could not find application :logger_json`
- Added a `Nix Build` CI job that runs `nix build .#default` and `nix build .#dockerImage` on PRs to catch stale hashes before merge
- Documented the Nix hash update workflow in AGENTS.md so future dependency changes include hash updates

## Test plan
- [x] `nix build .#default` succeeds locally
- [x] `nix build .#dockerImage` succeeds locally
- [x] `mix precommit` passes (45 tests, 0 failures)
- [x] CI `Nix Build` job passes on this PR