### PR TITLE
feat: add GitHub links to pipeline view

### DIFF
--- a/lib/greenlight_web/live/pipeline_live.ex
+++ b/lib/greenlight_web/live/pipeline_live.ex
@@ -16,7 +16,9 @@ defmodule GreenlightWeb.PipelineLive do
         nodes: [],
         edges: [],
         workflow_runs: [],
-        page_title: "#{owner}/#{repo} - #{String.slice(sha, 0, 7)}"
+        page_title: "#{owner}/#{repo} - #{String.slice(sha, 0, 7)}",
+        github_url: "https://github.com/#{owner}/#{repo}/commit/#{sha}",
+        github_label: String.slice(sha, 0, 7)
       )
 
     WideEvent.add(
@@ -56,7 +58,14 @@ defmodule GreenlightWeb.PipelineLive do
         pr = Enum.find(pulls, fn p -> p.number == String.to_integer(number) end)
 
         if pr do
-          mount(%{"owner" => owner, "repo" => repo, "sha" => pr.head_sha}, session, socket)
+          {:ok, socket} =
+            mount(%{"owner" => owner, "repo" => repo, "sha" => pr.head_sha}, session, socket)
+
+          {:ok,
+           assign(socket,
+             github_url: "https://github.com/#{owner}/#{repo}/pull/#{number}",
+             github_label: "PR ##{number}"
+           )}
         else
           {:ok,
            socket
@@ -79,7 +88,14 @@ defmodule GreenlightWeb.PipelineLive do
         run = Enum.find(runs, fn r -> r.head_sha end)
 
         if run do
-          mount(%{"owner" => owner, "repo" => repo, "sha" => run.head_sha}, session, socket)
+          {:ok, socket} =
+            mount(%{"owner" => owner, "repo" => repo, "sha" => run.head_sha}, session, socket)
+
+          {:ok,
+           assign(socket,
+             github_url: "https://github.com/#{owner}/#{repo}/releases/tag/#{tag}",
+             github_label: tag
+           )}
         else
           {:ok,
            socket
@@ -131,6 +147,23 @@ defmodule GreenlightWeb.PipelineLive do
             </.link>
             <span class="text-[var(--gl-border)]">/</span>
             <span class="text-[var(--gl-accent)]">{String.slice(@sha, 0, 7)}</span>
+            <span class="text-[var(--gl-border)]">·</span>
+            <a
+              href={@github_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="inline-flex items-center gap-1.5 text-[var(--gl-text-muted)] hover:text-[var(--gl-accent)] transition-colors"
+            >
+              <svg
+                viewBox="0 0 16 16"
+                fill="currentColor"
+                class="w-4 h-4"
+                aria-hidden="true"
+              >
+                <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+              </svg>
+              {@github_label}
+            </a>
           </div>
           <h1 class="text-3xl font-bold text-white uppercase tracking-wider">
             Pipeline


### PR DESCRIPTION
## Summary
- Adds context-aware GitHub links to the pipeline breadcrumb bar in PipelineLive
- PR routes show a GitHub icon + "PR #N" linking to the pull request on GitHub
- Commit routes show a GitHub icon + short SHA linking to the commit on GitHub
- Release routes show a GitHub icon + tag name linking to the release on GitHub

## Test plan
- [x] `mix precommit` passes (57 tests, 0 failures, nix build succeeds)
- [ ] Navigate to a PR pipeline → verify link goes to correct GitHub PR
- [ ] Navigate to a commit pipeline → verify link goes to correct GitHub commit
- [ ] Navigate to a release pipeline → verify link goes to correct GitHub release
- [ ] Verify hover styling matches design system (muted → green accent)