### PR TITLE
feat: add paginated full views for user PRs and commits

### DIFF
--- a/docs/plans/2026-03-06-pr-and-commit-full-views-design.md
+++ b/docs/plans/2026-03-06-pr-and-commit-full-views-design.md
@@ -1,0 +1,111 @@
+# PR and Commit Full Views Design
+
+## Overview
+
+Extend the dashboard's "Recent Pull Requests" and "Recent Commits" sections with clickable "View all" links that navigate to dedicated full-view pages with pagination.
+
+## Routes
+
+```
+/:username/pulls    -> UserPullsLive
+/:username/commits  -> UserCommitsLive
+```
+
+- Username is part of the URL to support viewing other users' activity in the future
+- Pagination via query param: `?page=N` (default: 1)
+- Page size: 10 items per page
+- Total cached items: 50
+
+## Architecture
+
+### Data Flow
+
+```
+Dashboard / Full View LiveViews
+        |
+UserInsightsServer.get_cached()  (read from cache)
+        |
+UserInsightsServer (polls every 5 min)
+        |
+Greenlight.GitHub.list_user_prs(username, %{per_page: 50})
+Greenlight.GitHub.list_user_commits(username, %{per_page: 50})
+        |
+ManualRead Actions (extract per_page from query.arguments)
+        |
+GitHub.Client (accepts optional per_page param)
+        |
+GitHub REST API (/search/issues, /search/commits)
+```
+
+### Changes by Layer
+
+#### 1. GitHub Client (`lib/greenlight/github/client.ex`)
+
+- `search_user_prs/2` and `search_user_commits/2` accept an optional opts map
+- Extract `per_page` from opts, default to 50
+- Pass through to GitHub API query params
+
+#### 2. Ash Resources (`user_pr.ex`, `user_commit.ex`)
+
+- Add optional `argument(:per_page, :integer)` to the `list` action on both resources
+- `allow_nil?` defaults to `true` so it's optional
+
+#### 3. ManualRead Actions (`actions/list_user_prs.ex`, `actions/list_user_commits.ex`)
+
+- Extract `per_page` from `query.arguments`, filter nils
+- Pass as opts map to Client functions
+- Follows existing pattern from `ListWorkflowRuns`
+
+#### 4. Domain (`domain.ex`)
+
+- No changes needed to `define` calls
+- Optional args passed as map: `Greenlight.GitHub.list_user_prs(username, %{per_page: 50})`
+
+#### 5. UserInsightsServer (`user_insights_server.ex`)
+
+- Change `per_page` from 5 to 50 in `fetch_user_insights/0`
+- Pass `%{per_page: 50}` through the Ash domain calls
+- Cached data structure unchanged, just more items
+
+#### 6. Dashboard LiveView (`dashboard_live.ex`)
+
+- Add "View all ->" links next to "Recent Pull Requests" and "Recent Commits" headers
+- Links point to `/:username/pulls` and `/:username/commits`
+- Use `Enum.take(5)` to slice the first 5 items for the preview cards
+
+#### 7. New LiveViews
+
+**`UserPullsLive`** (`lib/greenlight_web/live/user_pulls_live.ex`)
+- Mounts with `username` param from URL
+- `handle_params` reads `page` from query string (default 1)
+- Reads from `UserInsightsServer.get_cached()` if username matches authenticated user
+- Paginates with `Enum.slice(items, (page - 1) * 10, 10)`
+- Same card style as dashboard for consistency
+- Pagination controls: Previous / Next with page indicator
+
+**`UserCommitsLive`** (`lib/greenlight_web/live/user_commits_live.ex`)
+- Same pattern as `UserPullsLive` but for commits
+
+#### 8. Router (`router.ex`)
+
+- Add routes in the authenticated `live_session`:
+  ```elixir
+  live "/:username/pulls", UserPullsLive
+  live "/:username/commits", UserCommitsLive
+  ```
+
+## Pagination Logic
+
+```elixir
+page = max(String.to_integer(params["page"] || "1"), 1)
+page_size = 10
+total_items = length(all_items)
+total_pages = max(ceil(total_items / page_size), 1)
+page = min(page, total_pages)
+items = Enum.slice(all_items, (page - 1) * page_size, page_size)
+```
+
+## Future Considerations
+
+- When `username` does not match the authenticated user, fetch on-demand from the GitHub API instead of reading from cache
+- Could increase cached items beyond 50 or add search/filtering

--- a/docs/plans/2026-03-06-pr-and-commit-full-views-plan.md
+++ b/docs/plans/2026-03-06-pr-and-commit-full-views-plan.md
@@ -1,0 +1,762 @@
+# PR and Commit Full Views Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add paginated full-view pages for user PRs and commits at `/:username/pulls` and `/:username/commits`, accessible via "View all" links on the dashboard.
+
+**Architecture:** Extend the GitHub Client and Ash actions to support an optional `per_page` parameter. Increase `UserInsightsServer` cache from 5 to 50 items. Add two new LiveViews that read from cache and paginate client-side (10 per page). Dashboard shows first 5 items with "View all" links.
+
+**Tech Stack:** Elixir, Phoenix LiveView, Ash Framework 3.x, Tailwind CSS
+
+---
+
+### Task 1: Add optional `per_page` to GitHub Client functions
+
+**Files:**
+- Modify: `lib/greenlight/github/client.ex:143-205`
+
+**Step 1: Modify `search_user_prs/1` to accept opts**
+
+Change the function signature and use `per_page` from opts:
+
+```elixir
+def search_user_prs(username, opts \\ %{}) do
+  per_page = Map.get(opts, :per_page, 50)
+
+  case Req.get(new(),
+         url: "/search/issues",
+         params: %{q: "author:#{username} type:pr sort:updated", per_page: per_page}
+       ) do
+```
+
+The rest of the function body stays the same.
+
+**Step 2: Modify `search_user_commits/1` to accept opts**
+
+Same pattern:
+
+```elixir
+def search_user_commits(username, opts \\ %{}) do
+  per_page = Map.get(opts, :per_page, 50)
+
+  case Req.get(new(),
+         url: "/search/commits",
+         params: %{q: "author:#{username} sort:author-date", per_page: per_page}
+       ) do
+```
+
+**Step 3: Verify it compiles**
+
+Run: `mix compile --warnings-as-errors`
+Expected: SUCCESS
+
+**Step 4: Commit**
+
+```
+feat: add optional per_page param to GitHub client search functions
+```
+
+---
+
+### Task 2: Add optional `per_page` argument to Ash resources and actions
+
+**Files:**
+- Modify: `lib/greenlight/github/user_pr.ex:18-24`
+- Modify: `lib/greenlight/github/user_commit.ex:17-23`
+- Modify: `lib/greenlight/github/actions/list_user_prs.ex:7-10`
+- Modify: `lib/greenlight/github/actions/list_user_commits.ex:7-10`
+
+**Step 1: Add `per_page` argument to UserPR resource**
+
+In `lib/greenlight/github/user_pr.ex`, add the argument inside the `read :list` block:
+
+```elixir
+actions do
+  read :list do
+    argument(:username, :string, allow_nil?: false)
+    argument(:per_page, :integer)
+
+    manual(Greenlight.GitHub.Actions.ListUserPRs)
+  end
+end
+```
+
+**Step 2: Add `per_page` argument to UserCommit resource**
+
+Same change in `lib/greenlight/github/user_commit.ex`:
+
+```elixir
+actions do
+  read :list do
+    argument(:username, :string, allow_nil?: false)
+    argument(:per_page, :integer)
+
+    manual(Greenlight.GitHub.Actions.ListUserCommits)
+  end
+end
+```
+
+**Step 3: Update ListUserPRs action to pass optional args**
+
+In `lib/greenlight/github/actions/list_user_prs.ex`, extract `per_page` from query arguments and pass to client. Follow the pattern from `ListWorkflowRuns`:
+
+```elixir
+def read(query, _data_layer_query, _opts, _context) do
+  username = query.arguments.username
+
+  opts =
+    [:per_page]
+    |> Enum.map(fn key -> {key, Map.get(query.arguments, key)} end)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+
+  case Client.search_user_prs(username, opts) do
+```
+
+**Step 4: Update ListUserCommits action the same way**
+
+In `lib/greenlight/github/actions/list_user_commits.ex`:
+
+```elixir
+def read(query, _data_layer_query, _opts, _context) do
+  username = query.arguments.username
+
+  opts =
+    [:per_page]
+    |> Enum.map(fn key -> {key, Map.get(query.arguments, key)} end)
+    |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    |> Map.new()
+
+  case Client.search_user_commits(username, opts) do
+```
+
+**Step 5: Verify it compiles**
+
+Run: `mix compile --warnings-as-errors`
+Expected: SUCCESS
+
+**Step 6: Commit**
+
+```
+feat: add optional per_page argument to Ash UserPR and UserCommit actions
+```
+
+---
+
+### Task 3: Update UserInsightsServer to fetch 50 items
+
+**Files:**
+- Modify: `lib/greenlight/github/user_insights_server.ex:66-89`
+
+**Step 1: Pass `per_page: 50` to domain calls**
+
+In `fetch_user_insights/0`, update the Task.async calls to pass the per_page option:
+
+```elixir
+defp fetch_user_insights do
+  case Greenlight.GitHub.get_authenticated_user() do
+    {:ok, [user | _]} ->
+      prs_task = Task.async(fn -> Greenlight.GitHub.list_user_prs(user.login, %{per_page: 50}) end)
+      commits_task = Task.async(fn -> Greenlight.GitHub.list_user_commits(user.login, %{per_page: 50}) end)
+```
+
+The rest of the function stays the same.
+
+**Step 2: Verify it compiles**
+
+Run: `mix compile --warnings-as-errors`
+Expected: SUCCESS
+
+**Step 3: Commit**
+
+```
+feat: increase UserInsightsServer cache to 50 PRs and commits
+```
+
+---
+
+### Task 4: Update dashboard to show first 5 items and "View all" links
+
+**Files:**
+- Modify: `lib/greenlight_web/live/dashboard_live.ex:128-194`
+
+**Step 1: Add "View all" links and limit to 5 items**
+
+Update the PRs section header (around line 129) to include a "View all" link:
+
+```heex
+<div class="flex items-center justify-between mb-3">
+  <h3 class="text-sm font-bold uppercase tracking-wider text-[var(--gl-accent)] flex items-center gap-2">
+    <span class="w-1.5 h-1.5 bg-[var(--gl-accent)]" /> Recent Pull Requests
+  </h3>
+  <.link
+    navigate={"/#{@user.login}/pulls"}
+    class="text-xs text-[var(--gl-text-muted)] hover:text-[var(--gl-accent)] transition-colors uppercase tracking-wider"
+  >
+    View all &rarr;
+  </.link>
+</div>
+```
+
+Change the `:for` on the PR cards to slice to 5:
+
+```heex
+<.link
+  :for={pr <- Enum.take(@user_prs, 5)}
+```
+
+Update the Commits section header the same way (around line 169):
+
+```heex
+<div class="flex items-center justify-between mb-3">
+  <h3 class="text-sm font-bold uppercase tracking-wider text-[var(--gl-accent)] flex items-center gap-2">
+    <span class="w-1.5 h-1.5 bg-[var(--gl-accent)]" /> Recent Commits
+  </h3>
+  <.link
+    navigate={"/#{@user.login}/commits"}
+    class="text-xs text-[var(--gl-text-muted)] hover:text-[var(--gl-accent)] transition-colors uppercase tracking-wider"
+  >
+    View all &rarr;
+  </.link>
+</div>
+```
+
+Change the `:for` on commit cards:
+
+```heex
+<.link
+  :for={commit <- Enum.take(@user_commits, 5)}
+```
+
+**Step 2: Run existing tests**
+
+Run: `mix test test/greenlight_web/live/dashboard_live_test.exs`
+Expected: All 4 tests PASS (existing behavior preserved)
+
+**Step 3: Commit**
+
+```
+feat: add "View all" links to dashboard PR and commit sections
+```
+
+---
+
+### Task 5: Create UserPullsLive
+
+**Files:**
+- Create: `lib/greenlight_web/live/user_pulls_live.ex`
+
+**Step 1: Write the test file**
+
+Create `test/greenlight_web/live/user_pulls_live_test.exs`:
+
+```elixir
+defmodule GreenlightWeb.UserPullsLiveTest do
+  use GreenlightWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Greenlight.Cache
+
+  @prs Enum.map(1..15, fn i ->
+    %{
+      number: i,
+      title: "PR number #{i}",
+      state: "open",
+      html_url: "https://github.com/owner/repo/pull/#{i}",
+      updated_at: "2026-03-0#{min(i, 9)}T10:00:00Z",
+      repo: "owner/repo"
+    }
+  end)
+
+  setup do
+    Cache.init()
+
+    Req.Test.stub(Greenlight.GitHub.Client, fn conn ->
+      Req.Test.json(conn, %{})
+    end)
+
+    Cache.put(:user_insights, %{
+      user: %{login: "testuser", name: "Test User", avatar_url: "https://example.com/avatar.png"},
+      prs: @prs,
+      commits: [],
+      loading: false
+    })
+
+    :ok
+  end
+
+  test "renders first page of PRs", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls")
+    html = render(view)
+
+    assert html =~ "PR number 1"
+    assert html =~ "PR number 10"
+    refute html =~ "PR number 11"
+  end
+
+  test "renders second page of PRs", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls?page=2")
+    html = render(view)
+
+    assert html =~ "PR number 11"
+    assert html =~ "PR number 15"
+    refute html =~ "PR number 1"
+  end
+
+  test "renders pagination controls", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls")
+    html = render(view)
+
+    assert has_element?(view, "#pulls-pagination")
+    assert html =~ "Page 1 of 2"
+  end
+
+  test "navigates between pages", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls")
+
+    html =
+      view
+      |> element("#pulls-next")
+      |> render_click()
+
+    assert_patched(view, "/testuser/pulls?page=2")
+  end
+
+  test "shows page title with username", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/testuser/pulls")
+    assert html =~ "testuser"
+    assert html =~ "Pull Requests"
+  end
+end
+```
+
+**Step 2: Run the test to see it fail**
+
+Run: `mix test test/greenlight_web/live/user_pulls_live_test.exs`
+Expected: FAIL (module does not exist, route not defined)
+
+**Step 3: Create the LiveView module**
+
+Create `lib/greenlight_web/live/user_pulls_live.ex`:
+
+```elixir
+defmodule GreenlightWeb.UserPullsLive do
+  use GreenlightWeb, :live_view
+
+  alias Greenlight.GitHub.UserInsightsServer
+  import Greenlight.TimeHelpers, only: [relative_time: 1]
+
+  @page_size 10
+
+  @impl true
+  def mount(%{"username" => username}, _session, socket) do
+    cached = UserInsightsServer.get_cached()
+
+    if connected?(socket), do: UserInsightsServer.subscribe()
+
+    {:ok,
+     assign(socket,
+       page_title: "#{username} · Pull Requests",
+       username: username,
+       all_prs: cached.prs
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    all_prs = socket.assigns.all_prs
+    total = length(all_prs)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = params |> Map.get("page", "1") |> String.to_integer() |> max(1) |> min(total_pages)
+    items = Enum.slice(all_prs, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       page: page,
+       total_pages: total_pages,
+       prs: items
+     )}
+  end
+
+  @impl true
+  def handle_info({:user_insights_update, data}, socket) do
+    all_prs = data.prs
+    total = length(all_prs)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = min(socket.assigns.page, total_pages)
+    items = Enum.slice(all_prs, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       all_prs: all_prs,
+       page: page,
+       total_pages: total_pages,
+       prs: items
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-8">
+          <.link navigate="/" class="text-[var(--gl-text-muted)] hover:text-white transition-colors">
+            <.icon name="hero-arrow-left" class="w-5 h-5" />
+          </.link>
+          <h1 class="text-3xl font-bold uppercase tracking-wider text-white">
+            Pull Requests
+          </h1>
+          <span class="text-lg text-[var(--gl-text-muted)]">
+            · {@username}
+          </span>
+        </div>
+
+        <div :if={@prs == []} class="nb-card p-8 text-center">
+          <p class="text-[var(--gl-text-muted)]">No pull requests found</p>
+        </div>
+
+        <div class="space-y-2">
+          <.link
+            :for={pr <- @prs}
+            navigate={"/repos/#{pr.repo}/pull/#{pr.number}"}
+            class="nb-card-muted block p-4 group"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="min-w-0 flex-1">
+                <span class="text-xs text-[var(--gl-text-muted)] block">{pr.repo}</span>
+                <span class="text-sm text-white font-bold group-hover:text-[var(--gl-accent)] transition-colors block truncate">
+                  {pr.title}
+                </span>
+              </div>
+              <span class={[
+                "text-xs px-1.5 py-0.5 border font-bold shrink-0",
+                if(pr.state == "open",
+                  do: "text-[var(--gl-status-success)] border-[var(--gl-status-success)]",
+                  else: "text-[var(--gl-text-muted)] border-[var(--gl-border)]"
+                )
+              ]}>
+                {pr.state}
+              </span>
+            </div>
+            <div class="flex items-center gap-2 mt-1 text-xs text-[var(--gl-text-muted)]">
+              <span>#{pr.number}</span>
+              <span>·</span>
+              <span>{relative_time(pr.updated_at)}</span>
+            </div>
+          </.link>
+        </div>
+
+        <div :if={@total_pages > 1} id="pulls-pagination" class="flex items-center justify-center gap-4 mt-8">
+          <.link
+            :if={@page > 1}
+            patch={"/#{@username}/pulls?page=#{@page - 1}"}
+            id="pulls-prev"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            &larr; Previous
+          </.link>
+          <span class="text-sm text-[var(--gl-text-muted)]">
+            Page {@page} of {@total_pages}
+          </span>
+          <.link
+            :if={@page < @total_pages}
+            patch={"/#{@username}/pulls?page=#{@page + 1}"}
+            id="pulls-next"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            Next &rarr;
+          </.link>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end
+```
+
+**Step 4: Add route to router**
+
+In `lib/greenlight_web/router.ex`, add inside the `scope "/", GreenlightWeb` block after line 25:
+
+```elixir
+live "/:username/pulls", UserPullsLive
+```
+
+**Step 5: Run the tests**
+
+Run: `mix test test/greenlight_web/live/user_pulls_live_test.exs`
+Expected: All 5 tests PASS
+
+**Step 6: Commit**
+
+```
+feat: add UserPullsLive with paginated full view
+```
+
+---
+
+### Task 6: Create UserCommitsLive
+
+**Files:**
+- Create: `lib/greenlight_web/live/user_commits_live.ex`
+
+**Step 1: Write the test file**
+
+Create `test/greenlight_web/live/user_commits_live_test.exs`:
+
+```elixir
+defmodule GreenlightWeb.UserCommitsLiveTest do
+  use GreenlightWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Greenlight.Cache
+
+  @commits Enum.map(1..15, fn i ->
+    %{
+      sha: "abc#{String.pad_leading(Integer.to_string(i), 10, "0")}",
+      message: "Commit message #{i}",
+      repo: "owner/repo",
+      html_url: "https://github.com/owner/repo/commit/abc#{String.pad_leading(Integer.to_string(i), 10, "0")}",
+      authored_at: "2026-03-0#{min(i, 9)}T10:00:00Z"
+    }
+  end)
+
+  setup do
+    Cache.init()
+
+    Req.Test.stub(Greenlight.GitHub.Client, fn conn ->
+      Req.Test.json(conn, %{})
+    end)
+
+    Cache.put(:user_insights, %{
+      user: %{login: "testuser", name: "Test User", avatar_url: "https://example.com/avatar.png"},
+      prs: [],
+      commits: @commits,
+      loading: false
+    })
+
+    :ok
+  end
+
+  test "renders first page of commits", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits")
+    html = render(view)
+
+    assert html =~ "Commit message 1"
+    assert html =~ "Commit message 10"
+    refute html =~ "Commit message 11"
+  end
+
+  test "renders second page of commits", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits?page=2")
+    html = render(view)
+
+    assert html =~ "Commit message 11"
+    assert html =~ "Commit message 15"
+    refute html =~ "Commit message 1"
+  end
+
+  test "renders pagination controls", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits")
+    html = render(view)
+
+    assert has_element?(view, "#commits-pagination")
+    assert html =~ "Page 1 of 2"
+  end
+
+  test "navigates between pages", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits")
+
+    html =
+      view
+      |> element("#commits-next")
+      |> render_click()
+
+    assert_patched(view, "/testuser/commits?page=2")
+  end
+
+  test "shows page title with username", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/testuser/commits")
+    assert html =~ "testuser"
+    assert html =~ "Commits"
+  end
+end
+```
+
+**Step 2: Run the test to see it fail**
+
+Run: `mix test test/greenlight_web/live/user_commits_live_test.exs`
+Expected: FAIL (module does not exist, route not defined)
+
+**Step 3: Create the LiveView module**
+
+Create `lib/greenlight_web/live/user_commits_live.ex`:
+
+```elixir
+defmodule GreenlightWeb.UserCommitsLive do
+  use GreenlightWeb, :live_view
+
+  alias Greenlight.GitHub.UserInsightsServer
+  import Greenlight.TimeHelpers, only: [relative_time: 1]
+
+  @page_size 10
+
+  @impl true
+  def mount(%{"username" => username}, _session, socket) do
+    cached = UserInsightsServer.get_cached()
+
+    if connected?(socket), do: UserInsightsServer.subscribe()
+
+    {:ok,
+     assign(socket,
+       page_title: "#{username} · Commits",
+       username: username,
+       all_commits: cached.commits
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    all_commits = socket.assigns.all_commits
+    total = length(all_commits)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = params |> Map.get("page", "1") |> String.to_integer() |> max(1) |> min(total_pages)
+    items = Enum.slice(all_commits, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       page: page,
+       total_pages: total_pages,
+       commits: items
+     )}
+  end
+
+  @impl true
+  def handle_info({:user_insights_update, data}, socket) do
+    all_commits = data.commits
+    total = length(all_commits)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = min(socket.assigns.page, total_pages)
+    items = Enum.slice(all_commits, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       all_commits: all_commits,
+       page: page,
+       total_pages: total_pages,
+       commits: items
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-8">
+          <.link navigate="/" class="text-[var(--gl-text-muted)] hover:text-white transition-colors">
+            <.icon name="hero-arrow-left" class="w-5 h-5" />
+          </.link>
+          <h1 class="text-3xl font-bold uppercase tracking-wider text-white">
+            Commits
+          </h1>
+          <span class="text-lg text-[var(--gl-text-muted)]">
+            · {@username}
+          </span>
+        </div>
+
+        <div :if={@commits == []} class="nb-card p-8 text-center">
+          <p class="text-[var(--gl-text-muted)]">No commits found</p>
+        </div>
+
+        <div class="space-y-2">
+          <.link
+            :for={commit <- @commits}
+            navigate={"/repos/#{commit.repo}/commit/#{commit.sha}"}
+            class="nb-card-muted block p-4 group"
+          >
+            <div class="min-w-0">
+              <span class="text-xs text-[var(--gl-text-muted)] block">{commit.repo}</span>
+              <span class="text-sm text-white font-bold group-hover:text-[var(--gl-accent)] transition-colors block truncate">
+                {commit.message}
+              </span>
+            </div>
+            <div class="flex items-center gap-2 mt-1 text-xs text-[var(--gl-text-muted)]">
+              <span>{String.slice(commit.sha, 0, 7)}</span>
+              <span>·</span>
+              <span>{relative_time(commit.authored_at)}</span>
+            </div>
+          </.link>
+        </div>
+
+        <div :if={@total_pages > 1} id="commits-pagination" class="flex items-center justify-center gap-4 mt-8">
+          <.link
+            :if={@page > 1}
+            patch={"/#{@username}/commits?page=#{@page - 1}"}
+            id="commits-prev"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            &larr; Previous
+          </.link>
+          <span class="text-sm text-[var(--gl-text-muted)]">
+            Page {@page} of {@total_pages}
+          </span>
+          <.link
+            :if={@page < @total_pages}
+            patch={"/#{@username}/commits?page=#{@page + 1}"}
+            id="commits-next"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            Next &rarr;
+          </.link>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end
+```
+
+**Step 4: Add route to router**
+
+In `lib/greenlight_web/router.ex`, add after the pulls route:
+
+```elixir
+live "/:username/commits", UserCommitsLive
+```
+
+**Step 5: Run the tests**
+
+Run: `mix test test/greenlight_web/live/user_commits_live_test.exs`
+Expected: All 5 tests PASS
+
+**Step 6: Commit**
+
+```
+feat: add UserCommitsLive with paginated full view
+```
+
+---
+
+### Task 7: Run full test suite and verify
+
+**Step 1: Run all tests**
+
+Run: `mix test`
+Expected: All tests PASS
+
+**Step 2: Run precommit checks**
+
+Run: `mix precommit`
+Expected: SUCCESS (compile + format + credo + tests)
+
+**Step 3: Fix any issues found**
+
+If any tests fail or warnings appear, fix them.
+
+**Step 4: Final commit if any fixes were needed**
+
+```
+fix: address precommit issues
+```

--- a/lib/greenlight/github/actions/list_user_commits.ex
+++ b/lib/greenlight/github/actions/list_user_commits.ex
@@ -7,7 +7,13 @@ defmodule Greenlight.GitHub.Actions.ListUserCommits do
   def read(query, _data_layer_query, _opts, _context) do
     username = query.arguments.username
 
-    case Client.search_user_commits(username) do
+    opts =
+      [:per_page]
+      |> Enum.map(fn key -> {key, Map.get(query.arguments, key)} end)
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+
+    case Client.search_user_commits(username, opts) do
       {:ok, commits} ->
         ash_commits =
           Enum.map(commits, fn c ->

--- a/lib/greenlight/github/actions/list_user_prs.ex
+++ b/lib/greenlight/github/actions/list_user_prs.ex
@@ -7,7 +7,13 @@ defmodule Greenlight.GitHub.Actions.ListUserPRs do
   def read(query, _data_layer_query, _opts, _context) do
     username = query.arguments.username
 
-    case Client.search_user_prs(username) do
+    opts =
+      [:per_page]
+      |> Enum.map(fn key -> {key, Map.get(query.arguments, key)} end)
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+      |> Map.new()
+
+    case Client.search_user_prs(username, opts) do
       {:ok, prs} ->
         ash_prs =
           Enum.map(prs, fn pr ->

--- a/lib/greenlight/github/client.ex
+++ b/lib/greenlight/github/client.ex
@@ -140,10 +140,12 @@ defmodule Greenlight.GitHub.Client do
     end
   end
 
-  def search_user_prs(username) do
+  def search_user_prs(username, opts \\ %{}) do
+    per_page = Map.get(opts, :per_page, 50)
+
     case Req.get(new(),
            url: "/search/issues",
-           params: %{q: "author:#{username} type:pr sort:updated", per_page: 5}
+           params: %{q: "author:#{username} type:pr sort:updated", per_page: per_page}
          ) do
       {:ok, %{status: 200, body: body}} ->
         prs =
@@ -172,10 +174,12 @@ defmodule Greenlight.GitHub.Client do
     end
   end
 
-  def search_user_commits(username) do
+  def search_user_commits(username, opts \\ %{}) do
+    per_page = Map.get(opts, :per_page, 50)
+
     case Req.get(new(),
            url: "/search/commits",
-           params: %{q: "author:#{username} sort:author-date", per_page: 5}
+           params: %{q: "author:#{username} sort:author-date", per_page: per_page}
          ) do
       {:ok, %{status: 200, body: body}} ->
         commits =

--- a/lib/greenlight/github/user_commit.ex
+++ b/lib/greenlight/github/user_commit.ex
@@ -17,6 +17,7 @@ defmodule Greenlight.GitHub.UserCommit do
   actions do
     read :list do
       argument(:username, :string, allow_nil?: false)
+      argument(:per_page, :integer)
 
       manual(Greenlight.GitHub.Actions.ListUserCommits)
     end

--- a/lib/greenlight/github/user_insights_server.ex
+++ b/lib/greenlight/github/user_insights_server.ex
@@ -66,8 +66,11 @@ defmodule Greenlight.GitHub.UserInsightsServer do
   defp fetch_user_insights do
     case Greenlight.GitHub.get_authenticated_user() do
       {:ok, [user | _]} ->
-        prs_task = Task.async(fn -> Greenlight.GitHub.list_user_prs(user.login, %{per_page: 50}) end)
-        commits_task = Task.async(fn -> Greenlight.GitHub.list_user_commits(user.login, %{per_page: 50}) end)
+        prs_task =
+          Task.async(fn -> Greenlight.GitHub.list_user_prs(user.login, %{per_page: 50}) end)
+
+        commits_task =
+          Task.async(fn -> Greenlight.GitHub.list_user_commits(user.login, %{per_page: 50}) end)
 
         prs =
           case Task.await(prs_task) do

--- a/lib/greenlight/github/user_insights_server.ex
+++ b/lib/greenlight/github/user_insights_server.ex
@@ -66,8 +66,8 @@ defmodule Greenlight.GitHub.UserInsightsServer do
   defp fetch_user_insights do
     case Greenlight.GitHub.get_authenticated_user() do
       {:ok, [user | _]} ->
-        prs_task = Task.async(fn -> Greenlight.GitHub.list_user_prs(user.login) end)
-        commits_task = Task.async(fn -> Greenlight.GitHub.list_user_commits(user.login) end)
+        prs_task = Task.async(fn -> Greenlight.GitHub.list_user_prs(user.login, %{per_page: 50}) end)
+        commits_task = Task.async(fn -> Greenlight.GitHub.list_user_commits(user.login, %{per_page: 50}) end)
 
         prs =
           case Task.await(prs_task) do

--- a/lib/greenlight/github/user_pr.ex
+++ b/lib/greenlight/github/user_pr.ex
@@ -18,6 +18,7 @@ defmodule Greenlight.GitHub.UserPR do
   actions do
     read :list do
       argument(:username, :string, allow_nil?: false)
+      argument(:per_page, :integer)
 
       manual(Greenlight.GitHub.Actions.ListUserPRs)
     end

--- a/lib/greenlight_web/live/dashboard_live.ex
+++ b/lib/greenlight_web/live/dashboard_live.ex
@@ -126,15 +126,23 @@ defmodule GreenlightWeb.DashboardLive do
             <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
               <%!-- Recent PRs column --%>
               <div>
-                <h3 class="text-sm font-bold uppercase tracking-wider text-[var(--gl-accent)] mb-3 flex items-center gap-2">
-                  <span class="w-1.5 h-1.5 bg-[var(--gl-accent)]" /> Recent Pull Requests
-                </h3>
+                <div class="flex items-center justify-between mb-3">
+                  <h3 class="text-sm font-bold uppercase tracking-wider text-[var(--gl-accent)] flex items-center gap-2">
+                    <span class="w-1.5 h-1.5 bg-[var(--gl-accent)]" /> Recent Pull Requests
+                  </h3>
+                  <.link
+                    navigate={"/#{@user.login}/pulls"}
+                    class="text-xs text-[var(--gl-text-muted)] hover:text-[var(--gl-accent)] transition-colors uppercase tracking-wider"
+                  >
+                    View all &rarr;
+                  </.link>
+                </div>
                 <div :if={@user_prs == []} class="text-sm text-[var(--gl-text-muted)] py-4">
                   No recent pull requests
                 </div>
                 <div class="space-y-2">
                   <.link
-                    :for={pr <- @user_prs}
+                    :for={pr <- Enum.take(@user_prs, 5)}
                     navigate={"/repos/#{pr.repo}/pull/#{pr.number}"}
                     class="nb-card-muted block p-3 group"
                   >
@@ -166,15 +174,23 @@ defmodule GreenlightWeb.DashboardLive do
 
               <%!-- Recent Commits column --%>
               <div>
-                <h3 class="text-sm font-bold uppercase tracking-wider text-[var(--gl-accent)] mb-3 flex items-center gap-2">
-                  <span class="w-1.5 h-1.5 bg-[var(--gl-accent)]" /> Recent Commits
-                </h3>
+                <div class="flex items-center justify-between mb-3">
+                  <h3 class="text-sm font-bold uppercase tracking-wider text-[var(--gl-accent)] flex items-center gap-2">
+                    <span class="w-1.5 h-1.5 bg-[var(--gl-accent)]" /> Recent Commits
+                  </h3>
+                  <.link
+                    navigate={"/#{@user.login}/commits"}
+                    class="text-xs text-[var(--gl-text-muted)] hover:text-[var(--gl-accent)] transition-colors uppercase tracking-wider"
+                  >
+                    View all &rarr;
+                  </.link>
+                </div>
                 <div :if={@user_commits == []} class="text-sm text-[var(--gl-text-muted)] py-4">
                   No recent commits
                 </div>
                 <div class="space-y-2">
                   <.link
-                    :for={commit <- @user_commits}
+                    :for={commit <- Enum.take(@user_commits, 5)}
                     navigate={"/repos/#{commit.repo}/commit/#{commit.sha}"}
                     class="nb-card-muted block p-3 group"
                   >

--- a/lib/greenlight_web/live/user_commits_live.ex
+++ b/lib/greenlight_web/live/user_commits_live.ex
@@ -1,0 +1,126 @@
+defmodule GreenlightWeb.UserCommitsLive do
+  use GreenlightWeb, :live_view
+
+  alias Greenlight.GitHub.UserInsightsServer
+  import Greenlight.TimeHelpers, only: [relative_time: 1]
+
+  @page_size 10
+
+  @impl true
+  def mount(%{"username" => username}, _session, socket) do
+    cached = UserInsightsServer.get_cached()
+
+    if connected?(socket), do: UserInsightsServer.subscribe()
+
+    {:ok,
+     assign(socket,
+       page_title: "#{username} · Commits",
+       username: username,
+       all_commits: cached.commits
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    all_commits = socket.assigns.all_commits
+    total = length(all_commits)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = params |> Map.get("page", "1") |> String.to_integer() |> max(1) |> min(total_pages)
+    items = Enum.slice(all_commits, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       page: page,
+       total_pages: total_pages,
+       commits: items
+     )}
+  end
+
+  @impl true
+  def handle_info({:user_insights_update, data}, socket) do
+    all_commits = data.commits
+    total = length(all_commits)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = min(socket.assigns.page, total_pages)
+    items = Enum.slice(all_commits, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       all_commits: all_commits,
+       page: page,
+       total_pages: total_pages,
+       commits: items
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-8">
+          <.link navigate="/" class="text-[var(--gl-text-muted)] hover:text-white transition-colors">
+            <.icon name="hero-arrow-left" class="w-5 h-5" />
+          </.link>
+          <h1 class="text-3xl font-bold uppercase tracking-wider text-white">
+            Commits
+          </h1>
+          <span class="text-lg text-[var(--gl-text-muted)]">
+            · {@username}
+          </span>
+        </div>
+
+        <div :if={@commits == []} class="nb-card p-8 text-center">
+          <p class="text-[var(--gl-text-muted)]">No commits found</p>
+        </div>
+
+        <div class="space-y-2">
+          <.link
+            :for={commit <- @commits}
+            navigate={"/repos/#{commit.repo}/commit/#{commit.sha}"}
+            class="nb-card-muted block p-4 group"
+          >
+            <div class="min-w-0">
+              <span class="text-xs text-[var(--gl-text-muted)] block">{commit.repo}</span>
+              <span class="text-sm text-white font-bold group-hover:text-[var(--gl-accent)] transition-colors block truncate">
+                {commit.message}
+              </span>
+            </div>
+            <div class="flex items-center gap-2 mt-1 text-xs text-[var(--gl-text-muted)]">
+              <span>{String.slice(commit.sha, 0, 7)}</span>
+              <span>·</span>
+              <span>{relative_time(commit.authored_at)}</span>
+            </div>
+          </.link>
+        </div>
+
+        <div
+          :if={@total_pages > 1}
+          id="commits-pagination"
+          class="flex items-center justify-center gap-4 mt-8"
+        >
+          <.link
+            :if={@page > 1}
+            patch={"/#{@username}/commits?page=#{@page - 1}"}
+            id="commits-prev"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            &larr; Previous
+          </.link>
+          <span class="text-sm text-[var(--gl-text-muted)]">
+            Page {@page} of {@total_pages}
+          </span>
+          <.link
+            :if={@page < @total_pages}
+            patch={"/#{@username}/commits?page=#{@page + 1}"}
+            id="commits-next"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            Next &rarr;
+          </.link>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/greenlight_web/live/user_pulls_live.ex
+++ b/lib/greenlight_web/live/user_pulls_live.ex
@@ -1,0 +1,133 @@
+defmodule GreenlightWeb.UserPullsLive do
+  use GreenlightWeb, :live_view
+
+  alias Greenlight.GitHub.UserInsightsServer
+  import Greenlight.TimeHelpers, only: [relative_time: 1]
+
+  @page_size 10
+
+  @impl true
+  def mount(%{"username" => username}, _session, socket) do
+    cached = UserInsightsServer.get_cached()
+
+    if connected?(socket), do: UserInsightsServer.subscribe()
+
+    {:ok,
+     assign(socket,
+       page_title: "#{username} · Pull Requests",
+       username: username,
+       all_prs: cached.prs
+     )}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    all_prs = socket.assigns.all_prs
+    total = length(all_prs)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = params |> Map.get("page", "1") |> String.to_integer() |> max(1) |> min(total_pages)
+    items = Enum.slice(all_prs, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       page: page,
+       total_pages: total_pages,
+       prs: items
+     )}
+  end
+
+  @impl true
+  def handle_info({:user_insights_update, data}, socket) do
+    all_prs = data.prs
+    total = length(all_prs)
+    total_pages = max(ceil(total / @page_size), 1)
+    page = min(socket.assigns.page, total_pages)
+    items = Enum.slice(all_prs, (page - 1) * @page_size, @page_size)
+
+    {:noreply,
+     assign(socket,
+       all_prs: all_prs,
+       page: page,
+       total_pages: total_pages,
+       prs: items
+     )}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash}>
+      <div class="max-w-4xl mx-auto">
+        <div class="flex items-center gap-3 mb-8">
+          <.link navigate="/" class="text-[var(--gl-text-muted)] hover:text-white transition-colors">
+            <.icon name="hero-arrow-left" class="w-5 h-5" />
+          </.link>
+          <h1 class="text-3xl font-bold uppercase tracking-wider text-white">
+            Pull Requests
+          </h1>
+          <span class="text-lg text-[var(--gl-text-muted)]">
+            · {@username}
+          </span>
+        </div>
+
+        <div :if={@prs == []} class="nb-card p-8 text-center">
+          <p class="text-[var(--gl-text-muted)]">No pull requests found</p>
+        </div>
+
+        <div class="space-y-2">
+          <.link
+            :for={pr <- @prs}
+            navigate={"/repos/#{pr.repo}/pull/#{pr.number}"}
+            class="nb-card-muted block p-4 group"
+          >
+            <div class="flex items-start justify-between gap-2">
+              <div class="min-w-0 flex-1">
+                <span class="text-xs text-[var(--gl-text-muted)] block">{pr.repo}</span>
+                <span class="text-sm text-white font-bold group-hover:text-[var(--gl-accent)] transition-colors block truncate">
+                  {pr.title}
+                </span>
+              </div>
+              <span class={[
+                "text-xs px-1.5 py-0.5 border font-bold shrink-0",
+                if(pr.state == "open",
+                  do: "text-[var(--gl-status-success)] border-[var(--gl-status-success)]",
+                  else: "text-[var(--gl-text-muted)] border-[var(--gl-border)]"
+                )
+              ]}>
+                {pr.state}
+              </span>
+            </div>
+            <div class="flex items-center gap-2 mt-1 text-xs text-[var(--gl-text-muted)]">
+              <span>#{pr.number}</span>
+              <span>·</span>
+              <span>{relative_time(pr.updated_at)}</span>
+            </div>
+          </.link>
+        </div>
+
+        <div :if={@total_pages > 1} id="pulls-pagination" class="flex items-center justify-center gap-4 mt-8">
+          <.link
+            :if={@page > 1}
+            patch={"/#{@username}/pulls?page=#{@page - 1}"}
+            id="pulls-prev"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            &larr; Previous
+          </.link>
+          <span class="text-sm text-[var(--gl-text-muted)]">
+            Page {@page} of {@total_pages}
+          </span>
+          <.link
+            :if={@page < @total_pages}
+            patch={"/#{@username}/pulls?page=#{@page + 1}"}
+            id="pulls-next"
+            class="nb-card-muted px-4 py-2 text-sm font-bold text-white hover:text-[var(--gl-accent)] transition-colors"
+          >
+            Next &rarr;
+          </.link>
+        </div>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/greenlight_web/live/user_pulls_live.ex
+++ b/lib/greenlight_web/live/user_pulls_live.ex
@@ -105,7 +105,11 @@ defmodule GreenlightWeb.UserPullsLive do
           </.link>
         </div>
 
-        <div :if={@total_pages > 1} id="pulls-pagination" class="flex items-center justify-center gap-4 mt-8">
+        <div
+          :if={@total_pages > 1}
+          id="pulls-pagination"
+          class="flex items-center justify-center gap-4 mt-8"
+        >
           <.link
             :if={@page > 1}
             patch={"/#{@username}/pulls?page=#{@page - 1}"}

--- a/lib/greenlight_web/router.ex
+++ b/lib/greenlight_web/router.ex
@@ -23,6 +23,7 @@ defmodule GreenlightWeb.Router do
     live "/repos/:owner/:repo/commit/:sha", PipelineLive
     live "/repos/:owner/:repo/pull/:number", PipelineLive
     live "/repos/:owner/:repo/release/:tag", PipelineLive
+    live "/:username/pulls", UserPullsLive
   end
 
   # Other scopes may use custom stacks.

--- a/lib/greenlight_web/router.ex
+++ b/lib/greenlight_web/router.ex
@@ -24,6 +24,7 @@ defmodule GreenlightWeb.Router do
     live "/repos/:owner/:repo/pull/:number", PipelineLive
     live "/repos/:owner/:repo/release/:tag", PipelineLive
     live "/:username/pulls", UserPullsLive
+    live "/:username/commits", UserCommitsLive
   end
 
   # Other scopes may use custom stacks.

--- a/test/greenlight_web/live/user_commits_live_test.exs
+++ b/test/greenlight_web/live/user_commits_live_test.exs
@@ -1,0 +1,77 @@
+defmodule GreenlightWeb.UserCommitsLiveTest do
+  use GreenlightWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Greenlight.Cache
+
+  @commits Enum.map(1..15, fn i ->
+             %{
+               sha: "abc#{String.pad_leading(Integer.to_string(i), 10, "0")}",
+               message: "Commit message #{i}",
+               repo: "owner/repo",
+               html_url:
+                 "https://github.com/owner/repo/commit/abc#{String.pad_leading(Integer.to_string(i), 10, "0")}",
+               authored_at: "2026-03-0#{min(i, 9)}T10:00:00Z"
+             }
+           end)
+
+  setup do
+    Cache.init()
+
+    Req.Test.stub(Greenlight.GitHub.Client, fn conn ->
+      Req.Test.json(conn, %{})
+    end)
+
+    Cache.put(:user_insights, %{
+      user: %{login: "testuser", name: "Test User", avatar_url: "https://example.com/avatar.png"},
+      prs: [],
+      commits: @commits,
+      loading: false
+    })
+
+    :ok
+  end
+
+  test "renders first page of commits", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits")
+    html = render(view)
+
+    assert html =~ "Commit message 1"
+    assert html =~ "Commit message 10"
+    refute html =~ "Commit message 11"
+  end
+
+  test "renders second page of commits", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits?page=2")
+    html = render(view)
+
+    assert html =~ "Commit message 11"
+    assert html =~ "Commit message 15"
+    # Use link href to avoid substring match (e.g. "Commit message 1" matches "Commit message 10")
+    refute has_element?(view, "a[href='/repos/owner/repo/commit/abc0000000001']")
+  end
+
+  test "renders pagination controls", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits")
+    html = render(view)
+
+    assert has_element?(view, "#commits-pagination")
+    assert html =~ "Page 1 of 2"
+  end
+
+  test "navigates between pages", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/commits")
+
+    view
+    |> element("#commits-next")
+    |> render_click()
+
+    assert_patched(view, "/testuser/commits?page=2")
+  end
+
+  test "shows page title with username", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/testuser/commits")
+    assert html =~ "testuser"
+    assert html =~ "Commits"
+  end
+end

--- a/test/greenlight_web/live/user_pulls_live_test.exs
+++ b/test/greenlight_web/live/user_pulls_live_test.exs
@@ -5,15 +5,15 @@ defmodule GreenlightWeb.UserPullsLiveTest do
   alias Greenlight.Cache
 
   @prs Enum.map(1..15, fn i ->
-    %{
-      number: i,
-      title: "PR number #{i}",
-      state: "open",
-      html_url: "https://github.com/owner/repo/pull/#{i}",
-      updated_at: "2026-03-0#{min(i, 9)}T10:00:00Z",
-      repo: "owner/repo"
-    }
-  end)
+         %{
+           number: i,
+           title: "PR number #{i}",
+           state: "open",
+           html_url: "https://github.com/owner/repo/pull/#{i}",
+           updated_at: "2026-03-0#{min(i, 9)}T10:00:00Z",
+           repo: "owner/repo"
+         }
+       end)
 
   setup do
     Cache.init()

--- a/test/greenlight_web/live/user_pulls_live_test.exs
+++ b/test/greenlight_web/live/user_pulls_live_test.exs
@@ -1,0 +1,77 @@
+defmodule GreenlightWeb.UserPullsLiveTest do
+  use GreenlightWeb.ConnCase, async: false
+  import Phoenix.LiveViewTest
+
+  alias Greenlight.Cache
+
+  @prs Enum.map(1..15, fn i ->
+    %{
+      number: i,
+      title: "PR number #{i}",
+      state: "open",
+      html_url: "https://github.com/owner/repo/pull/#{i}",
+      updated_at: "2026-03-0#{min(i, 9)}T10:00:00Z",
+      repo: "owner/repo"
+    }
+  end)
+
+  setup do
+    Cache.init()
+
+    Req.Test.stub(Greenlight.GitHub.Client, fn conn ->
+      Req.Test.json(conn, %{})
+    end)
+
+    Cache.put(:user_insights, %{
+      user: %{login: "testuser", name: "Test User", avatar_url: "https://example.com/avatar.png"},
+      prs: @prs,
+      commits: [],
+      loading: false
+    })
+
+    :ok
+  end
+
+  test "renders first page of PRs", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls")
+    html = render(view)
+
+    assert html =~ "PR number 1"
+    assert html =~ "PR number 10"
+    refute html =~ "PR number 11"
+  end
+
+  test "renders second page of PRs", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls?page=2")
+    html = render(view)
+
+    assert html =~ "PR number 11"
+    assert html =~ "PR number 15"
+    # Use the link href to check page 1 items are absent (avoids substring match issues)
+    refute has_element?(view, "a[href='/repos/owner/repo/pull/10']")
+  end
+
+  test "renders pagination controls", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls")
+    html = render(view)
+
+    assert has_element?(view, "#pulls-pagination")
+    assert html =~ "Page 1 of 2"
+  end
+
+  test "navigates between pages", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/testuser/pulls")
+
+    view
+    |> element("#pulls-next")
+    |> render_click()
+
+    assert_patched(view, "/testuser/pulls?page=2")
+  end
+
+  test "shows page title with username", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/testuser/pulls")
+    assert html =~ "testuser"
+    assert html =~ "Pull Requests"
+  end
+end


### PR DESCRIPTION
## Summary

- Add `/:username/pulls` and `/:username/commits` routes with paginated full-view LiveViews (10 items per page)
- Increase `UserInsightsServer` cache from 5 to 50 items with optional `per_page` parameter flowing through Ash domain, actions, and GitHub client
- Add "View all →" links to dashboard PR and commit section headers, limit dashboard preview to 5 items

## Changes

### Backend
- **GitHub Client**: `search_user_prs/2` and `search_user_commits/2` accept optional `per_page` via opts map (default 50)
- **Ash Resources**: Added optional `per_page` argument to `UserPR` and `UserCommit` list actions
- **ManualRead Actions**: Extract `per_page` from query arguments, pass through to client (follows `ListWorkflowRuns` pattern)
- **UserInsightsServer**: Fetches 50 items per poll cycle instead of 5

### Frontend
- **Dashboard**: "View all →" links on section headers, `Enum.take(5)` for preview cards
- **UserPullsLive**: Full paginated view at `/:username/pulls` with `?page=N` query params
- **UserCommitsLive**: Full paginated view at `/:username/commits` with same pagination pattern
- Both views read from cache, subscribe for live updates, use `handle_params` for back/forward navigation

## Test Plan

- [x] 73 tests passing (10 new tests for the two LiveViews)
- [x] `mix precommit` passes (compile, format, credo, tests)
- [x] Nix build succeeds
- [ ] Manual: visit dashboard, click "View all →" links
- [ ] Manual: verify pagination controls on `/username/pulls` and `/username/commits`
- [ ] Manual: verify back/forward browser navigation between pages