### PR TITLE
fix(ci): move docker publish into release-please workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,12 @@
 name: Publish Release
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.2.0)"
+        required: true
+        type: string
 
 jobs:
   publish:
@@ -13,6 +17,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag }}
       - uses: DeterminateSystems/nix-installer-action@v21
       - uses: DeterminateSystems/magic-nix-cache-action@v13
       - name: Log in to GHCR
@@ -27,7 +33,7 @@ jobs:
         run: |
           set -euo pipefail
           docker load < ./result
-          VERSION="${GITHUB_REF_NAME}"
+          VERSION="${{ inputs.tag }}"
           docker tag ghcr.io/jordangarrison/greenlight:latest "ghcr.io/jordangarrison/greenlight:${VERSION}"
           docker push ghcr.io/jordangarrison/greenlight:latest
           docker push "ghcr.io/jordangarrison/greenlight:${VERSION}"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,8 +15,41 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+  publish:
+    name: Build & Push Release Image
+    needs: release
+    if: ${{ needs.release.outputs.release_created }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: DeterminateSystems/nix-installer-action@v21
+      - uses: DeterminateSystems/magic-nix-cache-action@v13
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build container image
+        run: nix build .#dockerImage
+      - name: Push release image
+        run: |
+          set -euo pipefail
+          docker load < ./result
+          VERSION="${{ needs.release.outputs.tag_name }}"
+          docker tag ghcr.io/jordangarrison/greenlight:latest "ghcr.io/jordangarrison/greenlight:${VERSION}"
+          docker push ghcr.io/jordangarrison/greenlight:latest
+          docker push "ghcr.io/jordangarrison/greenlight:${VERSION}"

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,12 @@
           shellHook = ''
             mix local.hex --if-missing --force
             mix local.rebar --if-missing --force
+
+            if [ ! -f _build/.setup_done ]; then
+              echo "First-time setup: running mix setup..."
+              mix setup
+              mkdir -p _build && touch _build/.setup_done
+            fi
           '';
         };
       }


### PR DESCRIPTION
## Summary

- Move Docker image build & push into the `release-please.yml` workflow as a dependent `publish` job that runs when `release_created` is true
- Use `tag_name` output from release-please to version-tag the Docker image (e.g. `v0.3.0`)
- Convert `publish.yml` from `release: [published]` trigger (which never fires due to GITHUB_TOKEN limitations) to `workflow_dispatch` for manual re-publishing

## Root Cause

When release-please creates a GitHub release using the default `GITHUB_TOKEN`, the resulting `release: [published]` event does **not** trigger other workflows. This is a GitHub security feature to prevent infinite workflow loops. The `publish.yml` workflow was never running.

## Test Plan

- [ ] Merge a release-please PR and verify the `publish` job runs in the Release Please workflow
- [ ] Verify the Docker image is pushed to GHCR with both `latest` and version tags
- [ ] Verify the `Publish Release` workflow can be manually triggered via `workflow_dispatch`